### PR TITLE
rename sde command in order to match with other commands syntax

### DIFF
--- a/src/Utils/Seat.php
+++ b/src/Utils/Seat.php
@@ -163,7 +163,7 @@ class Seat extends AbstractUtil
     {
 
         // Prep the path to php artisan
-        $command = $this->getArtisan() . ' eve:update-sde -n';
+        $command = $this->getArtisan() . ' eve:update:sde -n';
 
         // Run the setup command
         $success = $this->runCommandWithOutput($command, '');


### PR DESCRIPTION
depends on eveseat/console#21
depends on eveseat/docs#30
depends on eveseat/scripts#18