### PR TITLE
Add Ubuntu 18.04 LTS support, fix CentOS 6 support

### DIFF
--- a/resources/nginx-server-block-centos.conf
+++ b/resources/nginx-server-block-centos.conf
@@ -5,7 +5,7 @@
 user nginx;
 worker_processes auto;
 error_log /var/log/nginx/error.log;
-pid /run/nginx.pid;
+pid /var/run/nginx.pid;
 
 # Load dynamic modules. See /usr/share/nginx/README.dynamic.
 include /usr/share/nginx/modules/*.conf;

--- a/src/Commands/Install/Production.php
+++ b/src/Commands/Install/Production.php
@@ -435,6 +435,12 @@ class Production extends Command
         $supervisor->install();
         $supervisor->setup();
         $supervisor->setupIntegration($this->seat_destination);
+
+        // Terminate Horizon
+        $seat = new Seat($this->io);
+        $seat->setPath($this->seat_destination);
+        $seat->terminateHorizon();
+
         $supervisor->restart();
 
     }

--- a/src/Traits/DetectsOperatingSystem.php
+++ b/src/Traits/DetectsOperatingSystem.php
@@ -50,6 +50,10 @@ trait DetectsOperatingSystem
                 'version'   => '16.04',
                 'signature' => 'Ubuntu 16.04',
             ],
+            [
+                'version'   => '18.04',
+                'signature' => 'Ubuntu 18.04',
+            ],
         ],
         'centos' => [
             [

--- a/src/Utils/Apache.php
+++ b/src/Utils/Apache.php
@@ -51,6 +51,7 @@ class Apache extends AbstractUtil implements WebServer
     protected $webserver_users = [
         'ubuntu' => [
             '16.04' => 'www-data',
+            '18.04' => 'www-data',
         ],
         'centos' => [
             '6' => 'apache',

--- a/src/Utils/MySql.php
+++ b/src/Utils/MySql.php
@@ -63,8 +63,11 @@ class MySql extends AbstractUtil
                 'systemctl enable mysql.service',
                 'systemctl restart mysql.service',
             ],
+            '18.04' => [
+                'systemctl enable mysql.service',
+                'systemctl restart mysql.service',
+            ],
         ],
-
         'centos' => [
             '7' => [
                 'systemctl enable mariadb.service',

--- a/src/Utils/MySql.php
+++ b/src/Utils/MySql.php
@@ -71,8 +71,8 @@ class MySql extends AbstractUtil
                 'systemctl restart mariadb.service',
             ],
             '6' => [
-                'chkconfig mysqld on',
-                '/etc/init.d/mysqld restart',
+                'chkconfig mysql on',
+                '/etc/init.d/mysql restart',
             ],
         ],
         'debian' => [

--- a/src/Utils/Nginx.php
+++ b/src/Utils/Nginx.php
@@ -51,6 +51,7 @@ class Nginx extends AbstractUtil implements WebServer
     protected $webserver_users = [
         'ubuntu' => [
             '16.04' => 'www-data',
+            '18.04' => 'www-data',
         ],
         'centos' => [
             '6' => 'nginx',
@@ -68,6 +69,7 @@ class Nginx extends AbstractUtil implements WebServer
     protected $fpm_sockets = [
         'ubuntu' => [
             '16.04' => '/var/run/php/php7.1-fpm.sock',
+            '18.04' => '/var/run/php/php7.1-fpm.sock',
         ],
         'centos' => [
             '6' => '/var/run/php-fpm/php-fpm.sock',
@@ -85,6 +87,7 @@ class Nginx extends AbstractUtil implements WebServer
     protected $phpini_locations = [
         'ubuntu' => [
             '16.04' => '/etc/php/7.1/fpm/php.ini',
+            '18.04' => '/etc/php/7.1/fpm/php.ini',
         ],
         'centos' => [
             '6' => '/etc/php.ini',
@@ -102,6 +105,10 @@ class Nginx extends AbstractUtil implements WebServer
     protected $restart_commands = [
         'ubuntu' => [
             '16.04' => [
+                'systemctl restart nginx.service',
+                'systemctl restart php7.1-fpm.service',
+            ],
+            '18.04' => [
                 'systemctl restart nginx.service',
                 'systemctl restart php7.1-fpm.service',
             ],

--- a/src/Utils/PackageInstaller.php
+++ b/src/Utils/PackageInstaller.php
@@ -184,7 +184,7 @@ class PackageInstaller extends AbstractUtil
             // CentOS 6
             '6' => [
                 'mysql'      => [
-                    'mysql', 'mysql-server', 'expect',
+                    'MariaDB-server', 'expect',
                 ],
                 'php'        => [
                     'php-mysql', 'php-cli', 'php-mcrypt', 'php-process',

--- a/src/Utils/PackageInstaller.php
+++ b/src/Utils/PackageInstaller.php
@@ -57,6 +57,10 @@ class PackageInstaller extends AbstractUtil
                 'pdo_mysql' => 'php7.1-mysql',
                 'posix'     => 'php7.1-common',
             ],
+            '18.04' => [
+                'pdo_mysql' => 'php7.1-mysql',
+                'posix'     => 'php7.1-common',
+            ],
         ],
 
         'centos' => [
@@ -90,6 +94,11 @@ class PackageInstaller extends AbstractUtil
         // Ubuntu
         'ubuntu' => [
             '16.04' => [
+                'unzip'     => 'unzip',
+                'git'       => 'git',
+                'pdo_mysql' => 'php7.1-mysql',
+            ],
+            '18.04' => [
                 'unzip'     => 'unzip',
                 'git'       => 'git',
                 'pdo_mysql' => 'php7.1-mysql',
@@ -155,6 +164,29 @@ class PackageInstaller extends AbstractUtil
                     'supervisor',
                 ],
             ],
+            // Ubuntu 18.04 LTS
+            '18.04' => [
+                'mysql'      => [
+                    'mysql-server', 'expect',
+                ],
+                'php'        => [
+                    'php7.1-cli', 'php7.1-mcrypt', 'php7.1-intl',
+                    'php7.1-mysql', 'php7.1-curl', 'php7.1-gd',
+                    'php7.1-mbstring', 'php7.1-bz2', 'php7.1-dom',
+                ],
+                'apache'     => [
+                    'apache2', 'libapache2-mod-php7.1',
+                ],
+                'nginx'      => [
+                    'nginx', 'php7.1-fpm',
+                ],
+                'redis'      => [
+                    'redis-server',
+                ],
+                'supervisor' => [
+                    'supervisor',
+                ],
+            ],
         ],
 
         // CentOS
@@ -199,8 +231,10 @@ class PackageInstaller extends AbstractUtil
                 'redis'      => [
                     'redis',
                 ],
+                // We want to enable gf-plus repo only for supervisor, otherwise
+                // it starts updating things we do not want it to.
                 'supervisor' => [
-                    'supervisor',
+                    'supervisor --enablerepo=gf-plus',
                 ],
             ],
         ],

--- a/src/Utils/Requirements.php
+++ b/src/Utils/Requirements.php
@@ -46,7 +46,7 @@ class Requirements extends AbstractUtil
      * @var array
      */
     protected $supported_os = [
-        'ubuntu' => ['16.04'],
+        'ubuntu' => ['16.04', '18.04'],
         'centos' => ['6', '7'],
         'debian' => ['8', '9'],
     ];

--- a/src/Utils/Seat.php
+++ b/src/Utils/Seat.php
@@ -226,4 +226,17 @@ class Seat extends AbstractUtil
         if (! $success)
             throw new ArtisanCommandFailed('Unable to update the config cache');
     }
+
+    /**
+     * @throws \Seat\Installer\Exceptions\ArtisanCommandFailed
+     */
+    public function terminateHorizon()
+    {
+
+        $success = $this->runCommandWithOutput($this->getArtisan() .
+            ' horizon:terminate');
+
+        if (! $success)
+            throw new ArtisanCommandFailed('Unable to terminate Horizon');
+    }
 }

--- a/src/Utils/Supervisor.php
+++ b/src/Utils/Supervisor.php
@@ -157,7 +157,6 @@ class Supervisor extends AbstractUtil
 
         $this->writeConfig();
         $this->enable();
-        $this->restart();
     }
 
     /**

--- a/src/Utils/Supervisor.php
+++ b/src/Utils/Supervisor.php
@@ -54,6 +54,9 @@ class Supervisor extends AbstractUtil
             '16.04' => [
                 'systemctl enable supervisor.service',
             ],
+            '18.04' => [
+                'systemctl enable supervisor.service',
+            ],
         ],
         'centos' => [
             '7' => [
@@ -84,6 +87,9 @@ class Supervisor extends AbstractUtil
             '16.04' => [
                 'systemctl restart supervisor.service',
             ],
+            '18.04' => [
+                'systemctl restart supervisor.service',
+            ],
         ],
         'centos' => [
             '7' => [
@@ -111,6 +117,7 @@ class Supervisor extends AbstractUtil
     protected $seat_config_locations = [
         'ubuntu' => [
             '16.04' => '/etc/supervisor/conf.d/seat.conf',
+            '18.04' => '/etc/supervisor/conf.d/seat.conf',
         ],
         'centos' => [
             '7' => '/etc/supervisord.d/seat.ini',
@@ -128,6 +135,7 @@ class Supervisor extends AbstractUtil
     protected $supervisor_config_locations = [
         'ubuntu' => [
             '16.04' => '/etc/supervisor/supervisord.conf',
+            '18.04' => '/etc/supervisor/supervisord.conf',
         ],
         'centos' => [
             '7' => '/etc/supervisord.conf',


### PR DESCRIPTION
As per title, this PR fixes CentOS 6 support for SeAT v3, and also adds support for Ubuntu 18.04 LTS to the installer.

To be merged with required script updates: https://github.com/eveseat/scripts/pull/21